### PR TITLE
Simplify examples

### DIFF
--- a/src/Examples/ALagUsingFix.purs
+++ b/src/Examples/ALagUsingFix.purs
@@ -30,14 +30,16 @@ focus:ring-COLOR-500 focus:ring-offset-2 mr-4"""
 main :: Effect Unit
 main = runInBody Deku.do
   setWord /\ word <- useState'
+  let
+    button text color = D.button
+      (klass_ (buttonClass color) <|> click_ (setWord text))
+      [ text_ text ]
   D.div_
-    [ D.div_ $
-        [ "Hickory" /\ "green"
-        , "Dickory" /\ "pink"
-        , "Dock" /\ "indigo"
-        ] <#> \(w /\ k) -> D.button
-          (klass_ (buttonClass k) <|> click_ (setWord w))
-          [ text_ w ]
+    [ D.div_
+        [ button "Hickory" "green"
+        , button "Dickory" "pink"
+        , button "Dock" "indigo"
+        ]
     , D.div_
         [ text_ "Previous word: "
         , text

--- a/src/Examples/ANoteOnMemoization.purs
+++ b/src/Examples/ANoteOnMemoization.purs
@@ -40,14 +40,12 @@ main = do
               Alt.do
                 klass_ $ buttonClass "pink"
                 click_ $ random >>= setNumber
-              [ text_ "A"
-              ]
+              [ text_ "A" ]
           , D.button
               Alt.do
                 klass_ $ buttonClass "green"
                 click $ presence <#> not >>> setPresence
-              [ text_ "B"
-              ]
+              [ text_ "B" ]
           ]
       , D.div_
           [ guard presence

--- a/src/Examples/BooleanLogicOnEvents.purs
+++ b/src/Examples/BooleanLogicOnEvents.purs
@@ -71,16 +71,18 @@ main :: Effect Unit
 main = runInBody Deku.do
   setP /\ p <- useState true
   setQ /\ q <- useState true
-  let tdTableClass = klass_ tableClass
+  let
+    tdTableClass = klass_ tableClass
+    button setter letter value = D.button
+        (klass_ buttonClass <|> click_ (setter value))
+        [ text_ (letter <> " = " <> show value) ]
   D.div_
     [ D.div_ $
-        [ setP /\ "P" /\ true
-        , setP /\ "P" /\ false
-        , setQ /\ "Q" /\ true
-        , setQ /\ "Q" /\ false
-        ] <#> \(f /\ n /\ k) -> D.button
-          (klass_ buttonClass <|> click_ (f k))
-          [ text_ (n <> " = " <> show k) ]
+        [ button setP "P" true
+        , button setP "P" false
+        , button setQ "Q" true
+        , button setQ "Q" false
+        ]
     , D.table (klass_ tableClass)
         [ D.tr_
             [ D.th (klass_ tableClass) [ text_ "Equation" ]

--- a/src/Examples/EventsAsSemigroups.purs
+++ b/src/Examples/EventsAsSemigroups.purs
@@ -24,15 +24,17 @@ main :: Effect Unit
 main = runInBody Deku.do
   setKlass1 /\ klass1 <- useState "text-sm"
   setKlass2 /\ klass2 <- useState "text-green-500"
+  let
+    button setter text = D.button
+      (klass_ buttonClass <|> click_ (setter text))
+      [ text_ text ]
   D.div_
     [ D.div_ $
-        [ setKlass1 /\ "text-2xl"
-        , setKlass1 /\ "text-sm"
-        , setKlass2 /\ "text-orange-500"
-        , setKlass2 /\ "text-green-300"
-        ] <#> \(f /\ k) -> D.button
-          (klass_ buttonClass <|> click_ (f k))
-          [ text_ k ]
+        [ button setKlass1 "text-2xl"
+        , button setKlass1 "text-sm"
+        , button setKlass2 "text-orange-500"
+        , button setKlass2 "text-green-300"
+        ]
     , D.div_
         [ D.span (klass (klass1 <> pure " " <> klass2))
             [ text_ "Hello!" ]

--- a/src/Examples/OptimizedEventFunctions.purs
+++ b/src/Examples/OptimizedEventFunctions.purs
@@ -48,7 +48,7 @@ so be sure to alternate between the buttons."""
             click_ (setInt n)
             klass_ buttonClass
           [ text_ ("Add " <> show n) ]
-    , D.div_ [ text $ (show <$> fold (+) 0 (dedup int)) ]
+    , D.div_ [ text (show <$> fold (+) 0 (dedup int)) ]
     , D.div_
         [ text_ "And check out this pure number! "
         , text_ $ show $ run do

--- a/src/Examples/SeveralLagsUsingFix.purs
+++ b/src/Examples/SeveralLagsUsingFix.purs
@@ -39,14 +39,15 @@ main = runInBody Deku.do
                 (pure Nothing <|> (fst <$> ev))
                 ((Tuple <<< Just) <$> lag (n - 1) e)
             )
+    button text color = D.button
+      (klass_ (buttonClass color) <|> click_ (setWord text))
+      [ text_ text ]
   D.div_
     [ D.div_ $
-        [ "Hickory" /\ "green"
-        , "Dickory" /\ "pink"
-        , "Dock" /\ "indigo"
-        ] <#> \(w /\ k) -> D.button
-          (klass_ (buttonClass k) <|> click_ (setWord w))
-          [ text_ w ]
+        [ button "Hickory" "green"
+        , button "Dickory" "pink"
+        , button "Dock" "indigo"
+        ]
     , D.div_ $ [ 0, 1, 2, 3, 4 ] <#> \n -> D.div_
         [ text_ $ "Word with a lag of " <> show n <> ": "
         , text (pure "None" <|> lag n word)

--- a/src/Examples/TheLemmingEvent.purs
+++ b/src/Examples/TheLemmingEvent.purs
@@ -47,7 +47,7 @@ so be sure to alternate between the buttons."""
             click_ (setInt n)
             klass_ buttonClass
           [ text_ ("Add " <> show n) ]
-    , D.div_ [ text $ (show <$> fold (+) 0 (dedup int)) ]
+    , D.div_ [ text (show <$> fold (+) 0 (dedup int)) ]
     , D.div_
         [ text_ "And check out this pure number! "
         , text_ $ show $ run do

--- a/src/Examples/TheOneOfFunction.purs
+++ b/src/Examples/TheOneOfFunction.purs
@@ -15,17 +15,16 @@ main :: Effect Unit
 main = runInBody do
   let
     ms = 967
-    lyrics =
-      [ "Work it" /\ 0
-      , "Make it" /\ 1
-      , "Do it" /\ 2
-      , "Makes us" /\ 3
-      , "Harder" /\ 8
-      , "Better" /\ 9
-      , "Faster" /\ 10
-      , "Stronger" /\ 11
-      ]
     loop = 16 * ms
-    beat (w /\ t) =
-      delay (t * ms) (pure w <|> (interval loop $> w))
-  text (oneOf (beat <$> lyrics))
+    beat w t = delay (t * ms) (pure w <|> (interval loop $> w))
+  text $ oneOf 
+    [ beat "Work it" 0
+    , beat "Make it" 1
+    , beat "Do it" 2
+    , beat "Makes us" 3
+    , beat "Harder" 8
+    , beat "Better" 9
+    , beat "Faster" 10
+    , beat "Stronger" 11
+    ]
+


### PR DESCRIPTION
This PR mainly extracts lambdas that takes more then one argument as a pair, and instead of constructing the arrays of pairs and later mapping over that them the code now calls the function instead of where the pair operator was used.

This hopefully does two things:
 * it reduces the number of calls that happens in the code, reducing the packing and unpacking the reader and purescript needs to do.
 * it also moves the declaration of the function to before its "virtual" usage, making the code more linear and there by easier to read
 
 I have also tried to give the parameters longer names since they are now farther away from the callsite and you don't have the context of the actual values as close as before. (though its not that fara way in any of the cases).
 
 There is also some mild cleanups, removing extra `$` that it seemed was unnecessary.
 
 example:
 
 ```haskell
 D.div_
    [ D.div_ $
        [ setP /\ "P" /\ true
        , setP /\ "P" /\ false
        , setQ /\ "Q" /\ true
        , setQ /\ "Q" /\ false
        ] <#> \(f /\ n /\ k) -> D.button
          (klass_ buttonClass <|> click_ (f k))
          [ text_ (n <> " = " <> show k) ]
-- is turned into

let
    button setter letter value = D.button
        (klass_ buttonClass <|> click_ (setter value))
        [ text_ (letter <> " = " <> show value) ]
D.div_
    [ D.div_ $
      [ button setP "P" true
      , button setP "P" false
      , button setQ "Q" true
      , button setQ "Q" false
      ]
 ```