### PR TITLE
Syntax highlighting: bash → sh-session

### DIFF
--- a/src/Components/Code.purs
+++ b/src/Components/Code.purs
@@ -31,8 +31,8 @@ htmlCode code = D.pre (D.Class !:= "prism-code language-markup")
       ]
   ]
 
-bashCode :: forall lock payload. String -> Domable lock payload
-bashCode code = D.pre (D.Class !:= "prism-code language-bash")
+shSessionCode :: forall lock payload. String -> Domable lock payload
+shSessionCode code = D.pre (D.Class !:= "prism-code language-sh-session")
   [ D.code_
       [ text_ code
       ]

--- a/src/Pages/AdvancedUsage/CustomElements/UsingIonic/DefiningIonicCustomElements.purs
+++ b/src/Pages/AdvancedUsage/CustomElements/UsingIonic/DefiningIonicCustomElements.purs
@@ -2,7 +2,7 @@ module Pages.AdvancedUsage.CustomElements.UsingIonic.DefiningIonicCustomElements
 
 import Prelude
 
-import Components.Code (bashCode, jsCode)
+import Components.Code (jsCode, shSessionCode)
 import Contracts (Subsection, subsection)
 import Deku.Attribute ((!:=))
 import Deku.Control (text_)
@@ -18,7 +18,7 @@ definingIonicCustomElements = subsection
           , D.code__ "wc-discord-message"
           , text_ ", that'd be:"
           ]
-      , bashCode """pnpm i wc-discord-message"""
+      , shSessionCode """$ pnpm i wc-discord-message"""
       , D.p__ "And then:"
       , jsCode
           """import { applyPolyfills, defineCustomElements } from 'wc-discord-message/loader'

--- a/src/Pages/CoreConcepts/Pursx/ASimpleExample/TypeSafety.purs
+++ b/src/Pages/CoreConcepts/Pursx/ASimpleExample/TypeSafety.purs
@@ -2,7 +2,7 @@ module Pages.CoreConcepts.Pursx.ASimpleExample.TypeSafety where
 
 import Prelude
 
-import Components.Code (bashCode, psCode)
+import Components.Code (psCode, shSessionCode)
 import Contracts (Subsection, subsection)
 import Deku.Control (text_)
 import Deku.DOM as D
@@ -55,7 +55,7 @@ typeSafety = subsection
 main = runInBody ((Proxy :: Proxy
     "<h1><span>hi<span></h1>") ~~ {})"""
       , D.p_ [ text_ "The compiler complains with the following message." ]
-      , bashCode
+      , shSessionCode
           """  Could not match type
 
     "h1"

--- a/src/Pages/Introduction/GettingStarted/QuickStart/StartingANewProject.purs
+++ b/src/Pages/Introduction/GettingStarted/QuickStart/StartingANewProject.purs
@@ -1,7 +1,7 @@
 module Pages.Introduction.GettingStarted.QuickStart.StartingANewProject where
 
 
-import Components.Code (bashCode)
+import Components.Code (shSessionCode)
 import Contracts (Env(..), Subsection, subsection)
 import Deku.Attributes (klass_)
 import Deku.Control (text_)
@@ -17,7 +17,7 @@ startingANewProject = subsection
           , D.code_ [ text_ "create-deku-app" ]
           , text_ "."
           ]
-      , bashCode "npx create-deku-app my-awesome-app"
+      , shSessionCode "$ npx create-deku-app my-awesome-app"
       , D.p_
           [ text_
               "This will create a new Deku app in the directory "
@@ -31,7 +31,7 @@ startingANewProject = subsection
           [ text_
               "Just by doing this, you already have a full-fledged Deku app at the tips of your fingers. You can fire it up like so."
           ]
-      , bashCode "cd my-awesome-app && npx spago install && npm run dev"
+      , shSessionCode "$ cd my-awesome-app && npx spago install && npm run dev"
       , D.p_
           [ text_
               "Then, visit the link displayed in your terminal (usually "

--- a/src/Pages/Introduction/GettingStarted/QuickStart/UsingAnExistingProject.purs
+++ b/src/Pages/Introduction/GettingStarted/QuickStart/UsingAnExistingProject.purs
@@ -2,7 +2,7 @@ module Pages.Introduction.GettingStarted.QuickStart.UsingAnExistingProject where
 
 import Prelude
 
-import Components.Code (bashCode)
+import Components.Code (shSessionCode)
 import Components.Disclaimer (disclaimer)
 import Contracts (Subsection, subsection)
 import Deku.Control (text_)
@@ -16,12 +16,12 @@ usingAnExistingProject = subsection
           [ text_
               "If you have an existing project that does not yet have PureScript installed, you can install PureScript and related tooling with the following command."
           ]
-      , bashCode "npm install -D purescript spago purs-tidy && npx spago init"
+      , shSessionCode "$ npm install -D purescript spago purs-tidy && npx spago init"
       , D.p_
           [ text_
               "Once PureScript is installed, or if you're working from a project with PureScript already installed, you can install Deku with the following command."
           ]
-      , bashCode "npx spago install deku"
+      , shSessionCode "$ npx spago install deku"
       , disclaimer
           { header: text_ "Package sets"
           , message:

--- a/src/Prism.js
+++ b/src/Prism.js
@@ -1,7 +1,7 @@
 import * as Prism from 'prismjs'
 import 'prismjs/components/prism-haskell'
 import 'prismjs/components/prism-purescript'
-import 'prismjs/components/prism-bash'
+import 'prismjs/components/prism-shell-session'
 import 'prismjs/components/prism-javascript'
 import 'prismjs/components/prism-markup'
 import 'prismjs/plugins/autoloader/prism-autoloader'


### PR DESCRIPTION
The code blocks shown are all from an interactive shell sessions (e.g. in one’s terminal emulator). These were not Bash scripts (or even Bash per se as they are all valid POSIX shell) and shouldn’t be highlighted is if they were.