### PR TITLE
Use `Nut` in first example

### DIFF
--- a/src/Examples/ASimpleComponent.purs
+++ b/src/Examples/ASimpleComponent.purs
@@ -3,13 +3,19 @@ module Examples.ASimpleComponent where
 import Prelude
 
 import Deku.Control (text_)
+import Deku.Core (Nut)
 import Deku.DOM as D
 import Deku.Toplevel (runInBody)
 import Effect (Effect)
 
 main :: Effect Unit
-main = runInBody
-  ( D.div_
+main = runInBody mySimpleComponent
+  where
+  -- `Nut` is a convenience alias for the type for components
+  -- type Nut = forall lock payload. Domable lock payload
+  mySimpleComponent :: Nut
+  mySimpleComponent =
+    D.div_
       [ D.span__ "I exist"
       , D.ul_ $ map D.li__ [ "A", "B", "C" ]
       , D.div_
@@ -19,4 +25,3 @@ main = runInBody
           , D.b__ "baz"
           ]
       ]
-  )

--- a/src/Examples/ASimpleComponent.purs
+++ b/src/Examples/ASimpleComponent.purs
@@ -11,7 +11,7 @@ import Effect (Effect)
 main :: Effect Unit
 main = runInBody mySimpleComponent
   where
-  -- `Nut` is a convenience alias for the type for components
+  -- `Nut` is an alias for the type of Deku components
   -- type Nut = forall lock payload. Domable lock payload
   mySimpleComponent :: Nut
   mySimpleComponent =


### PR DESCRIPTION
When first trying to understand frameworks, I first skim code examples because that tells me a lot more and are clearer than the text. We, fans of the ML family, often look at the type signatures as a form of documentation. For me, adding the type of the component makes it clearer what’s going on—even if it is explained in bullet #2.